### PR TITLE
chore(ci/cd): Assigning domain alias to preview deployment

### DIFF
--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -49,6 +49,7 @@ jobs:
           vercel-org-id: ${{ secrets.VERCEL_ORG_ID }}
           vercel-project-id: ${{ secrets.VERCEL_PROJECT_ID }}
           scope: ${{ secrets.VERCEL_SCOPE }}
+          alias-domains: pr-{{PR_NUMBER}}-superface-docs.${{ secrets.VERCEL_DOMAIN }}
 
       - uses: bobheadxi/deployments@v0.4.3
         name: Finish deployment


### PR DESCRIPTION
This PR improves deployments for pull requests on docs.

Each commit in the PR gets deployed to `pr-{PR number}-superface-docs.vercel.app`. This allows for sharing always up-to-date deployment for the work done in the pull request.