### PR TITLE
feat: Adding Crisp to the site

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -17,6 +17,14 @@ module.exports = {
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'throw',
 
+  scripts: [
+    {
+      src: './crisp.js',
+      'crisp-website-id': process.env.CRISP_WEBSITE_ID || '',
+      defer: true,
+    },
+  ],
+
   themeConfig: {
     navbar: {
       title: undefined,
@@ -99,8 +107,7 @@ module.exports = {
         docs: {
           sidebarPath: require.resolve('./sidebars.js'),
           routeBasePath: '/',
-          editUrl:
-            'https://github.com/superfaceai/docs/edit/main/',
+          editUrl: 'https://github.com/superfaceai/docs/edit/main/',
           remarkPlugins: [remarkDeflist],
         },
         theme: {

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -19,7 +19,7 @@ module.exports = {
 
   scripts: [
     {
-      src: './crisp.js',
+      src: '/docs/crisp.js',
       'crisp-website-id': process.env.CRISP_WEBSITE_ID || '',
       defer: true,
     },

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -37,6 +37,10 @@ html[data-theme='dark'] {
   --ifm-background-surface-color: var(--tailwind-gray-900);
 }
 
+button[class*='backToTopButton'] {
+  display: none;
+}
+
 .docusaurus-highlight-code-line {
   background-color: rgba(0, 0, 0, 0.1);
   display: block;

--- a/static/crisp.js
+++ b/static/crisp.js
@@ -1,0 +1,13 @@
+window.$crisp = [];
+window.CRISP_WEBSITE_ID =
+  window.document.currentScript.getAttribute('crisp-website-id') || null;
+
+if (!!window.CRISP_WEBSITE_ID) {
+  (function () {
+    d = document;
+    s = d.createElement('script');
+    s.src = 'https://client.crisp.chat/l.js';
+    s.async = 1;
+    d.getElementsByTagName('head')[0].appendChild(s);
+  })();
+}


### PR DESCRIPTION
This PR adds [Crisp Chat](https://crisp.chat/en/) bubble to the Docs to continue the support experience from the main website.

---

The configuration fetches `CRISP_WEBSITE_ID` from env at build time and renders the following at every page:
```html
<script src="./crisp.js" crisp-website-id="4686a....." defer></script>
```

`crisp.js` then reads the website id from the `script` and sets up Crisp using their provided snippet.