### PR TITLE
chore: Pruning branches only removes deployments

### DIFF
--- a/.github/workflows/prune-closed-pr-deployments.yml
+++ b/.github/workflows/prune-closed-pr-deployments.yml
@@ -17,3 +17,4 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           environment: ${{ env.GITHUB_HEAD_REF_SLUG_URL }}
+          onlyRemoveDeployments: true


### PR DESCRIPTION
It turns out we actually need to run this, but since the repo is public, the workflow runs using a different access scope so we’re just removing the deployments from the environment.