### PR TITLE
Fix link to provider using API key in request query

### DIFF
--- a/docs/guides/add-new-provider.md
+++ b/docs/guides/add-new-provider.md
@@ -226,4 +226,4 @@ _e.g. `https://api.example.com/?accessKey=<apikey>`_
 - [Provider using Basic auth](https://github.com/superfaceai/station/blob/main/providers/twilio.json)
 - [Provider using Bearer token](https://github.com/superfaceai/station/blob/main/providers/slack.json)
 - [Provider using API key in request headers](https://github.com/superfaceai/station/blob/main/providers/dhl.json)
-- [Provider using API key in request query](https://github.com/superfaceai/station/blob/main/providers/google-apis.json)
+- [Provider using API key in request query](https://github.com/superfaceai/station/blob/main/providers/google-apis-maps.json)


### PR DESCRIPTION
This PR fixes link in `Add new provider` guide. `google-apis` has been renamed to `google-apis-maps`.