### PR TITLE
chore: Remove remark-deflist

### DIFF
--- a/docs/guides/create-new-capability.md
+++ b/docs/guides/create-new-capability.md
@@ -16,11 +16,8 @@ This guide assumes you have set up a Node.js project with Superface and OneSDK. 
 
 Profile's name must consist of lowercase letters, numbers, characters, dashes and underscores.
 
-Valid
-: `my_profile`, `myprofile123`, `my-profile`
-
-Invalid
-: `my profile`, `my+profile`, `MyProfile`
+- Valid: `my_profile`, `myprofile123`, `my-profile`
+- Invalid: `my profile`, `my+profile`, `MyProfile`
 
 While single profile file can contain multiple use-cases, we generally recommend to keep single use-case per profile. So the profile can be named after the use-case, for example:
 
@@ -151,14 +148,9 @@ If you prefer learning by example, you can check the source Comlink profile for 
 
 The use-case can be marked as `safe`, `unsafe` or `idempotent`. If the safety is not specified, the use-case is treated as `unsafe` by default.
 
-`safe`
-: The use-case doesn't change anything or doesn't perform any action. Generally reading operations can be considered safe, for example retrieving information about shipment or geocoding a postal address.
-
-`unsafe`
-: The use-case changes the world state and its retry may result in unintended side effects. For example, sending an email, or placing an order is unsafe: executing these use-cases repeatedly results in sending multiple emails or placing multiple orders.
-
-`idempotent`
-: The use-case can be executed multiple times without changing the result. For example updating an article with the same data multiple times results in the same article.
+- `safe`: The use-case doesn't change anything or doesn't perform any action. Generally reading operations can be considered safe, for example retrieving information about shipment or geocoding a postal address.
+- `unsafe`: The use-case changes the world state and its retry may result in unintended side effects. For example, sending an email, or placing an order is unsafe: executing these use-cases repeatedly results in sending multiple emails or placing multiple orders.
+- `idempotent`: The use-case can be executed multiple times without changing the result. For example updating an article with the same data multiple times results in the same article.
 
 :::info HTTP Methods
 
@@ -344,14 +336,15 @@ The types can be either _scalar_ or _collections_. Scalar types are primitive va
 
 Comlink supports the following collections:
 
-List
-: Corresponds to Array in JavaScript or List in Python.
-: Uses square brackets, e.g. `[string]` defines a list of strings.
+- List
 
-Object
-: Acts as a dictionary with strings for keys.
-: Corresponds to Object in JavaScript or Dictionary in Python.
-: Uses curly brackets, e.g. `{myField number}` defines an object with single field of type number.
+  - Corresponds to Array in JavaScript or List in Python.
+  - Uses square brackets, e.g. `[string]` defines a list of strings.
+
+- Object
+  - Acts as a dictionary with strings for keys.
+  - Corresponds to Object in JavaScript or Dictionary in Python.
+  - Uses curly brackets, e.g. `{myField number}` defines an object with single field of type number.
 
 Objects are commonly used to define inputs, results, and errors:
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -1,6 +1,5 @@
 const lightCodeTheme = require('prism-react-renderer/themes/github');
 const darkCodeTheme = require('prism-react-renderer/themes/dracula');
-const remarkDeflist = require('remark-deflist');
 
 /** @type {import('@docusaurus/types').DocusaurusConfig} */
 module.exports = {
@@ -108,7 +107,6 @@ module.exports = {
           sidebarPath: require.resolve('./sidebars.js'),
           routeBasePath: '/',
           editUrl: 'https://github.com/superfaceai/docs/edit/main/',
-          remarkPlugins: [remarkDeflist],
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "prism-react-renderer": "^1.2.1",
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
-    "remark-deflist": "^0.3.0",
     "url-loader": "^4.1.1"
   },
   "browserslist": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3202,7 +3202,7 @@ debug@^3.1.1, debug@^3.2.6:
   dependencies:
     ms "^2.1.1"
 
-debug@^4.0.0, debug@^4.1.0, debug@^4.1.1:
+debug@^4.1.0, debug@^4.1.1:
   version "4.3.2"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
   integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
@@ -5440,11 +5440,6 @@ loglevel@^1.6.8:
   resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.7.1.tgz#005fde2f5e6e47068f935ff28573e125ef72f197"
   integrity sha512-Hesni4s5UkWkwCGJMQGAh71PaLUmKFM60dHvq0zi/vDhhrzuk+4GgNbTXJ12YYQJn6ZKBDNIjYcuQGKudvqrIw==
 
-longest-streak@^2.0.0:
-  version "2.0.4"
-  resolved "https://registry.yarnpkg.com/longest-streak/-/longest-streak-2.0.4.tgz#b8599957da5b5dab64dee3fe316fa774597d90e4"
-  integrity sha512-vM6rUVCVUJJt33bnmHiZEvr7wPT78ztX7rojL+LW51bHtLh6HTjx84LA5W4+oa6aKEJA7jJu5LR6vQRBpA5DVg==
-
 loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.2.0, loose-envify@^1.3.1, loose-envify@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.4.0.tgz#71ee51fa7be4caec1a63839f7e682d8132d30caf"
@@ -5514,17 +5509,6 @@ mdast-util-definitions@^4.0.0:
   dependencies:
     unist-util-visit "^2.0.0"
 
-mdast-util-from-markdown@^0.8.4:
-  version "0.8.5"
-  resolved "https://registry.yarnpkg.com/mdast-util-from-markdown/-/mdast-util-from-markdown-0.8.5.tgz#d1ef2ca42bc377ecb0463a987910dae89bd9a28c"
-  integrity sha512-2hkTXtYYnr+NubD/g6KGBS/0mFmBcifAsI0yIWRiRo0PjVs6SSOSOdtzbp6kSGnShDN6G5aWZpKQ2lWRy27mWQ==
-  dependencies:
-    "@types/mdast" "^3.0.0"
-    mdast-util-to-string "^2.0.0"
-    micromark "~2.11.0"
-    parse-entities "^2.0.0"
-    unist-util-stringify-position "^2.0.0"
-
 mdast-util-to-hast@10.0.1:
   version "10.0.1"
   resolved "https://registry.yarnpkg.com/mdast-util-to-hast/-/mdast-util-to-hast-10.0.1.tgz#0cfc82089494c52d46eb0e3edb7a4eb2aea021eb"
@@ -5538,18 +5522,6 @@ mdast-util-to-hast@10.0.1:
     unist-util-generated "^1.0.0"
     unist-util-position "^3.0.0"
     unist-util-visit "^2.0.0"
-
-mdast-util-to-markdown@^0.6.1:
-  version "0.6.5"
-  resolved "https://registry.yarnpkg.com/mdast-util-to-markdown/-/mdast-util-to-markdown-0.6.5.tgz#b33f67ca820d69e6cc527a93d4039249b504bebe"
-  integrity sha512-XeV9sDE7ZlOQvs45C9UKMtfTcctcaj/pGwH8YLbMHoMOXNNCn2LsqVQOqrF1+/NU8lKDAqozme9SCXWyo9oAcQ==
-  dependencies:
-    "@types/unist" "^2.0.0"
-    longest-streak "^2.0.0"
-    mdast-util-to-string "^2.0.0"
-    parse-entities "^2.0.0"
-    repeat-string "^1.0.0"
-    zwitch "^1.0.0"
 
 mdast-util-to-string@^2.0.0:
   version "2.0.0"
@@ -5608,14 +5580,6 @@ microevent.ts@~0.1.1:
   version "0.1.1"
   resolved "https://registry.yarnpkg.com/microevent.ts/-/microevent.ts-0.1.1.tgz#70b09b83f43df5172d0205a63025bce0f7357fa0"
   integrity sha512-jo1OfR4TaEwd5HOrt5+tAZ9mqT4jmpNAusXtyfNzqVm9uiSYFZlKM1wYL4oU7azZW/PxQW53wM0S6OR1JHNa2g==
-
-micromark@~2.11.0:
-  version "2.11.4"
-  resolved "https://registry.yarnpkg.com/micromark/-/micromark-2.11.4.tgz#d13436138eea826383e822449c9a5c50ee44665a"
-  integrity sha512-+WoovN/ppKolQOFIAajxi7Lu9kInbPxFuTBVEavFcL8eAfVstoc5MocPmqBeAdBOJV00uaVjegzH4+MA0DN/uA==
-  dependencies:
-    debug "^4.0.0"
-    parse-entities "^2.0.0"
 
 micromatch@^3.1.10, micromatch@^3.1.4:
   version "3.1.10"
@@ -7124,16 +7088,6 @@ remark-admonitions@^1.2.1:
     unified "^8.4.2"
     unist-util-visit "^2.0.1"
 
-remark-deflist@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/remark-deflist/-/remark-deflist-0.3.0.tgz#392cf331289c5c9690f1cdb8171b304bf85a1075"
-  integrity sha512-LFHJeK5Yel3TuAACdEo4K3rs23xHJFQ/OLnrouJi2OWvmxHtGluCAsuJDrMpwm2P0QQoiGBut+zRdeeORAhUHg==
-  dependencies:
-    mdast-util-from-markdown "^0.8.4"
-    mdast-util-to-markdown "^0.6.1"
-    mdast-util-to-string "^2.0.0"
-    unist-util-visit "^2.0.3"
-
 remark-emoji@^2.1.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/remark-emoji/-/remark-emoji-2.2.0.tgz#1c702090a1525da5b80e15a8f963ef2c8236cac7"
@@ -7212,7 +7166,7 @@ repeat-element@^1.1.2:
   resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.4.tgz#be681520847ab58c7568ac75fbfad28ed42d39e9"
   integrity sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ==
 
-repeat-string@^1.0.0, repeat-string@^1.5.4, repeat-string@^1.6.1:
+repeat-string@^1.5.4, repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=


### PR DESCRIPTION
remark-deflist migrated to ES modules which is issue for backwards compatibility, but the package is otherwise quite unmaintained.

Deflists have only limited use in the current docs and present non-standard syntax. Let's just use bullet lists even if it's less semantically correct.