### PR TITLE
feat: Add OneSDK reference

### DIFF
--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -232,7 +232,7 @@ DEBUG="superface:http*" node index.js
 This can print out potentially sensitive information.
 :::
 
-Set the DEBUG value to `*` to see everything what is going in under the hood. Check [OneSDK's documentation and source code](https://github.com/superfaceai/one-sdk-js) for more details.
+Set the DEBUG value to `superface*` to see everything what is going in under the hood.
 
 ### Understand runtime integration
 

--- a/docs/getting-started.mdx
+++ b/docs/getting-started.mdx
@@ -232,7 +232,7 @@ DEBUG="superface:http*" node index.js
 This can print out potentially sensitive information.
 :::
 
-Set the DEBUG value to `superface*` to see everything what is going in under the hood.
+Set the DEBUG environment variable to `superface*` to see everything what is going in under the hood.
 
 ### Understand runtime integration
 

--- a/docs/guides/setup-the-environment.md
+++ b/docs/guides/setup-the-environment.md
@@ -49,7 +49,7 @@ It will create `superface` folder with the below structure
 - `types` - folder with generated types
 - `super.json` - superface configuration file
 
-And as last step install [OneSDK](/reference/one-sdk-js).
+And as last step install [OneSDK](/reference/one-sdk).
 
 ```shell
 npm install --save @superfaceai/one-sdk

--- a/docs/reference/one-sdk.mdx
+++ b/docs/reference/one-sdk.mdx
@@ -1,0 +1,136 @@
+---
+slug: '/reference/one-sdk'
+---
+
+# OneSDK for Node.js Reference
+
+OneSDK is a universal API client for Node.js. This page describes OneSDK public API and configuration options.
+
+## Important links
+
+- [OneSDK on GitHub](https://github.com/superfaceai/one-sdk-js) for reporting issues
+- [OneSDK on npm](https://www.npmjs.com/package/@superfaceai/one-sdk)
+- [Getting Started](/getting-started) tutorial
+
+## Installation
+
+OneSDK is available as Node package under the name `@superfaceai/one-sdk`. For installation in a Node.js run:
+
+```shell
+npm install @superfaceai/one-sdk
+```
+
+## Usage
+
+### Configuration
+
+OneSDK requires a configuration file, by default located in `superface/super.json` path. You can create this file using the [Superface CLI](https://github.com/superfaceai/cli) by installing a profile and configuring a provider:
+
+```shell
+npx @superfaceai/cli install <profileName>
+npx @superfaceai/cli configure <providerName> -p <profileName>
+```
+
+// TODO: tip where I can find them?
+
+### Initializing the OneSDK client
+
+OneSDK package exports `SuperfaceClient` constructor to initialize an SDK client:
+
+```typescript
+import { SuperfaceClient } from '@superface/one-sdk';
+
+const client = new SuperfaceClient();
+```
+
+### Performing a use-case
+
+With client initialized you can perform the use-cases in installed profiles.
+
+
+
+Make sure a profile is installed by running `superface install <profileName>[@<profileVersion>]` in the project directory, then load the profile:
+
+```typescript
+const profile = await client.getProfile('<profileName>');
+```
+
+Next, make sure at least one provider is configured in super.json or select one manually. You can configure providers in super.json by running `superface configure <providerName>` and you can add additional or overriding configuration by calling `.configure` on the Provider object:
+
+```typescript
+const provider = await client.getProvider('<providerName>');
+// provider.configure(...)
+```
+
+Then, obtain a use case and perform it with selected provider:
+
+```typescript
+const result = await profile.getUsecase('<usecaseName>').perform(
+  {
+    inputField: 1,
+    anotherInputField: 'hello',
+  },
+  // optional, if provider is missing selects first configured provider from super.json
+  { provider }
+);
+```
+
+### Handling the results from `perform`
+
+The `perform` method will take your inputs and additional information and perform the use case asynchronously. This method always returns a Result type that is either `Ok` or `Err`. This follows the [neverthrow](https://github.com/supermacro/neverthrow) approach. The SDK provides multiple ways to work with result.
+
+#### Conditionals
+
+You can use conditionals to check if the result was OK or if it errored. Use `isOk()` or `isErr()`to check type of result.
+
+```typescript
+if (result.isErr()) {
+  // Result is error, error.toString() returns human readable description of what went wrong
+  console.log(result.error.toString());
+} else {
+  // Result is ok and you can accees value here
+  console.log(result.value);
+}
+```
+
+#### Matching a value or error
+
+The Result type also provides a `match` method to use functions to use the values or errors. The `match` method takes two functions, the first of which is for handling the `Ok` result and the the second for handling the `Err` result. The example above using `isOk` and `isErr` can be written using `match` like below.
+
+```typescript
+result.match(
+  value => console.log(value),
+  error => console.log(error.toString())
+);
+```
+
+#### Unsafely unwrapping the result
+
+Lastly, you can just use `unwrap`, which is less safe because it will throw an error.
+
+```typescript
+try {
+  // Possible error is thrown here and it contains human readable description of what went wrong :)
+  const value = result.unwrap();
+  // You can accees value here
+  console.log(value);
+} catch (e) {
+  console.log(e);
+}
+```
+
+## Configuration
+
+The Superface OneSDK is configurable through various environment variables:
+
+- `SUPERFACE_SDK_TOKEN` - your auth token to integrate your running instance with Superface services
+- `SUPERFACE_API_URL` - URL of the Superface services, you probably don't need to change this; default is https://superface.ai
+- `SUPERFACE_PATH` - path to your super.json file; default is `./superface/super.json`
+- `SUPERFACE_METRIC_DEBOUNCE_TIME_MIN` and `SUPERFACE_METRIC_DEBOUNCE_TIME_MAX` - to rate limit metric reporting, OneSDK will send aggregated metrics after at least `MIN` milliseconds and at most `MAX` milliseconds; default is 1000 for min and 60000 for max
+- `SUPERFACE_DISABLE_METRIC_REPORTING` - set this variable to disable metric reporting; enabled by default
+
+### Working with results from `perform`
+
+## Configuration
+
+### Environment variables

--- a/docs/reference/one-sdk.mdx
+++ b/docs/reference/one-sdk.mdx
@@ -129,6 +129,6 @@ The Superface OneSDK is configurable through various environment variables:
 
 - `SUPERFACE_SDK_TOKEN` - auth token to enable [integrations monitoring dashboard](../integrations-monitoring)
 - `SUPERFACE_PATH` - path to the `super.json` configuration file; default is `./superface/super.json` (relative to current working directory)
-- `SUPERFACE_API_URL` - URL of the Superface services, useful for SDK development; default is `"https://superface.ai"`
+- `SUPERFACE_API_URL` - URL of the Superface services, useful for SDK development; default is `https://superface.ai`
 - `SUPERFACE_METRIC_DEBOUNCE_TIME_MIN` and `SUPERFACE_METRIC_DEBOUNCE_TIME_MAX` - to rate limit metric reporting, OneSDK will send aggregated metrics after at least `MIN` milliseconds and at most `MAX` milliseconds; default is 1000 for `MIN` and 60000 for `MAX`
 - `SUPERFACE_DISABLE_METRIC_REPORTING` - set this variable to any value to disable metrics reporting; enabled by default

--- a/docs/reference/one-sdk.mdx
+++ b/docs/reference/one-sdk.mdx
@@ -8,7 +8,7 @@ OneSDK is a universal API client for Node.js. This page describes OneSDK public 
 
 ## Important links
 
-- [OneSDK on GitHub](https://github.com/superfaceai/one-sdk-js) for reporting issues
+- [OneSDK on GitHub](https://github.com/superfaceai/one-sdk-js) for development and reporting issues
 - [OneSDK on npm](https://www.npmjs.com/package/@superfaceai/one-sdk)
 - [Getting Started](/getting-started) tutorial
 
@@ -43,59 +43,63 @@ import { SuperfaceClient } from '@superface/one-sdk';
 const client = new SuperfaceClient();
 ```
 
-### Performing a use-case
+### Performing a use-case (`getProfile`, `getUsecase`, `perform`)
 
-With client initialized you can perform the use-cases in installed profiles.
+With client initialized you can perform the use-cases in installed profiles using the following series of methods:
 
-
-
-Make sure a profile is installed by running `superface install <profileName>[@<profileVersion>]` in the project directory, then load the profile:
+1. `getProfile('<profileName>')` returns an instance of Profile from the SDK client instance,
+2. `getUsecase('<usecaseName>')` returns a use-case from Profile,
+3. `perform(input, [options])` executes the use-case with provided input data and optional `options` argument.
 
 ```typescript
 const profile = await client.getProfile('<profileName>');
+const result = await profile.getUsecase('<usecaseName>').perform({
+  inputField: 1,
+  anotherInputField: 'hello',
+});
 ```
 
-Next, make sure at least one provider is configured in super.json or select one manually. You can configure providers in super.json by running `superface configure <providerName>` and you can add additional or overriding configuration by calling `.configure` on the Provider object:
+Perform returns a [result object](#result-object).
+
+### Selecting a provider (`getProvider`) {#get-provider}
+
+By default, OneSDK picks the first configured provider according to the [`priority` array](/reference/superjson#profilesettings) in `super.json` configuration.
+
+You can get a specific provider with `getProvider` method on SDK client and passing it to the perform:
 
 ```typescript
 const provider = await client.getProvider('<providerName>');
-// provider.configure(...)
-```
-
-Then, obtain a use case and perform it with selected provider:
-
-```typescript
-const result = await profile.getUsecase('<usecaseName>').perform(
+const result = await profile.getUseCase('<usecaseName>').perform(
   {
-    inputField: 1,
-    anotherInputField: 'hello',
+    // Input parameters
   },
-  // optional, if provider is missing selects first configured provider from super.json
   { provider }
 );
 ```
 
-### Handling the results from `perform`
+You can read more in [using multiple providers](../guides/using-multiple-providers) guide.
 
-The `perform` method will take your inputs and additional information and perform the use case asynchronously. This method always returns a Result type that is either `Ok` or `Err`. This follows the [neverthrow](https://github.com/supermacro/neverthrow) approach. The SDK provides multiple ways to work with result.
+### Handling the result (`Result` type) {#result-object}
+
+The `perform` method always returns a `Result` type that is either `Ok` or `Err`. This follows the [NeverThrow](https://github.com/supermacro/neverthrow) approach. You can handle the Result in different ways.
 
 #### Conditionals
 
-You can use conditionals to check if the result was OK or if it errored. Use `isOk()` or `isErr()`to check type of result.
+Use `isOk()` or `isErr()`to check type of result in conditionals.
 
 ```typescript
 if (result.isErr()) {
   // Result is error, error.toString() returns human readable description of what went wrong
   console.log(result.error.toString());
 } else {
-  // Result is ok and you can accees value here
+  // Result is ok and you can access the result data through value
   console.log(result.value);
 }
 ```
 
 #### Matching a value or error
 
-The Result type also provides a `match` method to use functions to use the values or errors. The `match` method takes two functions, the first of which is for handling the `Ok` result and the the second for handling the `Err` result. The example above using `isOk` and `isErr` can be written using `match` like below.
+The `Result` provides a `match` method which accepts two functions. The first function handles the `Ok` result and the the second one handles the `Err` result. The conditionals example above can be rewritten using `match` like this:
 
 ```typescript
 result.match(
@@ -106,13 +110,13 @@ result.match(
 
 #### Unsafely unwrapping the result
 
-Lastly, you can just use `unwrap`, which is less safe because it will throw an error.
+Lastly, you can just use `unwrap` method which will either return a result value, or throw an error.
 
 ```typescript
 try {
   // Possible error is thrown here and it contains human readable description of what went wrong :)
   const value = result.unwrap();
-  // You can accees value here
+  // You can access value here
   console.log(value);
 } catch (e) {
   console.log(e);
@@ -123,14 +127,8 @@ try {
 
 The Superface OneSDK is configurable through various environment variables:
 
-- `SUPERFACE_SDK_TOKEN` - your auth token to integrate your running instance with Superface services
-- `SUPERFACE_API_URL` - URL of the Superface services, you probably don't need to change this; default is https://superface.ai
-- `SUPERFACE_PATH` - path to your super.json file; default is `./superface/super.json`
-- `SUPERFACE_METRIC_DEBOUNCE_TIME_MIN` and `SUPERFACE_METRIC_DEBOUNCE_TIME_MAX` - to rate limit metric reporting, OneSDK will send aggregated metrics after at least `MIN` milliseconds and at most `MAX` milliseconds; default is 1000 for min and 60000 for max
-- `SUPERFACE_DISABLE_METRIC_REPORTING` - set this variable to disable metric reporting; enabled by default
-
-### Working with results from `perform`
-
-## Configuration
-
-### Environment variables
+- `SUPERFACE_SDK_TOKEN` - auth token to enable [integrations monitoring dashboard](../integrations-monitoring)
+- `SUPERFACE_PATH` - path to the `super.json` configuration file; default is `./superface/super.json` (relative to current working directory)
+- `SUPERFACE_API_URL` - URL of the Superface services, useful for SDK development; default is `"https://superface.ai"`
+- `SUPERFACE_METRIC_DEBOUNCE_TIME_MIN` and `SUPERFACE_METRIC_DEBOUNCE_TIME_MAX` - to rate limit metric reporting, OneSDK will send aggregated metrics after at least `MIN` milliseconds and at most `MAX` milliseconds; default is 1000 for `MIN` and 60000 for `MAX`
+- `SUPERFACE_DISABLE_METRIC_REPORTING` - set this variable to any value to disable metrics reporting; enabled by default

--- a/docs/reference/one-sdk.mdx
+++ b/docs/reference/one-sdk.mdx
@@ -31,8 +31,6 @@ npx @superfaceai/cli install <profileName>
 npx @superfaceai/cli configure <providerName> -p <profileName>
 ```
 
-// TODO: tip where I can find them?
-
 ### Initializing the OneSDK client
 
 OneSDK package exports `SuperfaceClient` constructor to initialize an SDK client:

--- a/docs/reference/one-sdk.mdx
+++ b/docs/reference/one-sdk.mdx
@@ -61,9 +61,9 @@ Perform returns a [result object](#result-object).
 
 ### Selecting a provider (`getProvider`) {#get-provider}
 
-By default, OneSDK picks the first configured provider according to the [`priority` array](/reference/superjson#profilesettings) in `super.json` configuration.
+By default, OneSDK picks the first configured provider or the first provider according to profile's [`priority` array](/reference/superjson#profilesettings) in `super.json` configuration.
 
-You can get a specific provider with `getProvider` method on SDK client and passing it to the perform:
+You can choose a specific provider for `perform`. Use the `getProvider` method to obtain provider's configuration and pass it into `perform`:
 
 ```typescript
 const provider = await client.getProvider('<providerName>');
@@ -75,11 +75,11 @@ const result = await profile.getUseCase('<usecaseName>').perform(
 );
 ```
 
-You can read more in [using multiple providers](../guides/using-multiple-providers) guide.
+Read more in [using multiple providers](../guides/using-multiple-providers) guide.
 
 ### Handling the result (`Result` type) {#result-object}
 
-The `perform` method always returns a `Result` type that is either `Ok` or `Err`. This follows the [NeverThrow](https://github.com/supermacro/neverthrow) approach. You can handle the Result in different ways.
+The `perform` method always returns a `Result` type that is either `Ok` or `Err`. This follows the [NeverThrow](https://github.com/supermacro/neverthrow) approach. The `Result` type provides multiple approaches for handling the success and error conditions:
 
 #### Conditionals
 
@@ -130,3 +130,4 @@ The Superface OneSDK is configurable through various environment variables:
 - `SUPERFACE_API_URL` - URL of the Superface services, useful for SDK development; default is `https://superface.ai`
 - `SUPERFACE_METRIC_DEBOUNCE_TIME_MIN` and `SUPERFACE_METRIC_DEBOUNCE_TIME_MAX` - to rate limit metric reporting, OneSDK will send aggregated metrics after at least `MIN` milliseconds and at most `MAX` milliseconds; default is 1000 for `MIN` and 60000 for `MAX`
 - `SUPERFACE_DISABLE_METRIC_REPORTING` - set this variable to any value to disable metrics reporting; enabled by default
+- `DEBUG` - configures the [debugging output](https://github.com/debug-js/debug); disabled by default, to observe all debug messages relevant to OneSDK set this variable to `superface*`

--- a/docs/reference/reference-intro.mdx
+++ b/docs/reference/reference-intro.mdx
@@ -24,7 +24,7 @@ slug: /reference
       <div class="card__body">
         <h3>CLI</h3>
         <p>
-          Command line tool for managing Superface use-cases and providers in your projects.
+          CLI tool for installing API integrations.
         </p>
       </div>
       <div class="card__footer">
@@ -40,7 +40,7 @@ slug: /reference
       <div class="card__body">
         <h3>OneSDK for Node.js</h3>
         <p>
-          Client library for working with use-cases in your application.
+          Universal client library for all the APIs you want to integrate with.
         </p>
       </div>
       <div class="card__footer">

--- a/docs/reference/reference-intro.mdx
+++ b/docs/reference/reference-intro.mdx
@@ -10,11 +10,11 @@ slug: /reference
       <div class="card__body">
         <h3>Comlink</h3>
         <p>
-          Language for describing APIs and the business capabilities they provide.
+          Language for working with APIs and describing business use-cases they provide.
         </p>
       </div>
       <div class="card__footer">
-        <a href="/docs/comlink/" class="button button--primary button--block">Comlink Reference</a>
+        <a href="/docs/comlink" class="button button--primary button--block">Comlink Reference</a>
       </div>
     </div>
   </div>
@@ -24,11 +24,11 @@ slug: /reference
       <div class="card__body">
         <h3>CLI</h3>
         <p>
-          Superface CLI provides access to superface tooling from the command line.
+          Command line tool for managing Superface use-cases and providers in your projects.
         </p>
       </div>
       <div class="card__footer">
-        <a target="_blank" href="/docs/reference/cli" class="button button--primary button--block">CLI on GitHub</a>
+        <a href="https://github.com/superfaceai/cli" class="button button--primary button--block">Superface CLI on GitHub</a>
       </div>
     </div>
   </div>
@@ -38,13 +38,13 @@ slug: /reference
   <div class="col col--6">
     <div class="card shadow">
       <div class="card__body">
-        <h3>OneSDK.js</h3>
+        <h3>OneSDK for Node.js</h3>
         <p>
-          Client library that communicates with registry and performs operations from profiles/maps.
+          Client library for working with use-cases in your application.
         </p>
       </div>
       <div class="card__footer">
-        <a target="_blank" href="/docs/reference/one-sdk-js" class="button button--primary button--block">OneSDK.js on GitHub</a>
+        <a href="/docs/reference/one-sdk" class="button button--primary button--block">OneSDK Reference</a>
       </div>
     </div>
   </div>
@@ -54,11 +54,11 @@ slug: /reference
       <div class="card__body">
         <h3>super.json</h3>
         <p>
-          Primary configuration file for OneSDK.js.
+          Configuration file for OneSDK.
         </p>
       </div>
       <div class="card__footer">
-        <a href="/docs/reference/superjson" class="button button--primary button--block">super.json reference</a>
+        <a href="/docs/reference/superjson" class="button button--primary button--block">super.json Reference</a>
       </div>
     </div>
   </div>


### PR DESCRIPTION
This is to accommodate for stuff removed from OneSDK readme: https://github.com/superfaceai/one-sdk-js/tree/aafe33692021d046f2cf248377bc79541a546095#handling-the-results-from-perform