### PR TITLE
fix: “Add new provider ” keeps correct sidebar

### DIFF
--- a/sidebars.js
+++ b/sidebars.js
@@ -5,6 +5,10 @@
  - provide next/previous navigation
 
  Create as many sidebars as you want.
+
+ Note:
+ When a doc page is mentioned in multiple sidebars, the latter will take precedence
+ and will render in the docs.
  */
 
 module.exports = {

--- a/sidebars.js
+++ b/sidebars.js
@@ -13,11 +13,6 @@ module.exports = {
     'guides/add-new-provider',
   ],
   guidesSidebar: [
-    // {
-    //   type: 'doc',
-    //   id: 'guides-intro',
-    //   label: 'Overview'
-    // },
     'getting-started',
     'integrations-monitoring',
     'guides/api-keys',
@@ -29,7 +24,6 @@ module.exports = {
       items: [
         { type: 'doc', id: 'guides/how-to-create', label: 'Overview' },
         'guides/setup-the-environment',
-        // 'guides/create-new-profile', Uncomment this once the page si ready
         'guides/create-new-capability',
         'guides/add-new-provider',
         'guides/map-capability-to-provider',

--- a/sidebars.js
+++ b/sidebars.js
@@ -8,6 +8,10 @@
  */
 
 module.exports = {
+  providerAvailabilitySidebar: [
+    'guides/find-provider-by-name',
+    'guides/add-new-provider',
+  ],
   guidesSidebar: [
     // {
     //   type: 'doc',
@@ -34,10 +38,6 @@ module.exports = {
         'guides/publishing',
       ],
     },
-  ],
-  providerAvailabilitySidebar: [
-    'guides/find-provider-by-name',
-    'guides/add-new-provider',
   ],
   comlinkReferenceSidebar: [
     {


### PR DESCRIPTION
When opening [Add new provider](https://superface.ai/docs/guides/add-new-provider) guide, the sidebar switches non-authoring sidebar.

That sidebar is important to provide backward-continuity from [Find provider by name](https://superface.ai/docs/guides/find-provider-by-name) that is linked from the former guide, however it should only render on this specific page.

Fixes #68 

cc @SuperVrata 