### PR TITLE
fix: Invalid links, reference / spec

### DIFF
--- a/docs/comlink/reference/map.mdx
+++ b/docs/comlink/reference/map.mdx
@@ -10,7 +10,7 @@ Comlink Map is a format for describing how an API provider's services map to the
 
 - `profile` - the profile identifier to which the map corresponds
   - can be written without version: `starwars/character-information`
-  - can be writtent with version omitting the patch number: `starwars/character-information@1.1`
+  - can be written with version omitting the patch number: `starwars/character-information@1.1`
 - `provider` - corresponds to the provider identifier found in the Provider Definition
 - `variant` (optional) - allows for multiple maps for the same profile and provider
 
@@ -351,5 +351,5 @@ There are more features of the Comlink Map. Please refer to the [specifications]
 
 ## Examples
 
-- [Map with reusable operations, iterations & expressions](https://github.com/superfaceai/station/blob/main/capabilities/delivery-tracking/shipment-info/maps/dhl.suma)
-- [Map with multiple error response mappings](https://github.com/superfaceai/station/blob/main/capabilities/communication/send-email/maps/postmark.suma)
+- [Map with reusable operations, iterations & expressions](https://github.com/superfaceai/station/blob/51b021ddcdccc772c9a2cd1591c9936b9ba64a5d/grid/delivery-tracking/shipment-info/maps/dhl.suma)
+- [Map with multiple error response mappings](https://github.com/superfaceai/station/blob/51b021ddcdccc772c9a2cd1591c9936b9ba64a5d/grid/communication/send-email/maps/postmark.suma)

--- a/docs/guides/map-capability-to-provider.md
+++ b/docs/guides/map-capability-to-provider.md
@@ -378,7 +378,7 @@ _The above map expects the use case to fail in some scenarios when the user prov
 
 _Note: the `return` keyword serves the purpose of early return, as you might recognize from other programming languages. Without `return`, the execution would continue to the `map error` without any condition at the end, and that would overwrite the error returned from the response handler._
 
-_See [Comlink reference](https://superface.ai/docs/comlink/map#sec-Conditions) for more about conditions._
+_See [Comlink specification](https://superface.ai/docs/comlink/map#sec-Conditions) for more about conditions._
 
 ## Using functions, conditions, iterations and more {#advanced}
 
@@ -388,11 +388,11 @@ For more complicated maps, you'll find a need for the general programming concep
 
 :::tip
 
-Comlink supports everything you might expect from a powerful scripting language. We recommend to explore the language by consulting [Comlink Map reference](https://superface.ai/docs/comlink/map) or [the examples below](#examples).
+Comlink supports everything you might expect from a powerful scripting language. We recommend to explore the language by consulting [Comlink Map reference](../comlink/reference/map.mdx) or [the examples below](#examples).
 
 :::
 
 ## Examples {#examples}
 
-- [Map with reusable operations, iterations & expressions](https://github.com/superfaceai/station/blob/main/capabilities/delivery-tracking/shipment-info/maps/dhl.suma)
-- [Map with multiple error response mappings](https://github.com/superfaceai/station/blob/main/capabilities/communication/send-email/maps/postmark.suma)
+- [Map with reusable operations, iterations & expressions](https://github.com/superfaceai/station/blob/51b021ddcdccc772c9a2cd1591c9936b9ba64a5d/grid/delivery-tracking/shipment-info/maps/dhl.suma)
+- [Map with multiple error response mappings](https://github.com/superfaceai/station/blob/51b021ddcdccc772c9a2cd1591c9936b9ba64a5d/grid/communication/send-email/maps/postmark.suma)

--- a/docs/guides/test-capability.md
+++ b/docs/guides/test-capability.md
@@ -404,7 +404,7 @@ You can use `--updateSnapshot` flag when modifying tests or when the expected re
 
 ## Examples
 
-- [Integration test for expected result data format](https://github.com/superfaceai/station/blob/main/capabilities/communication/send-message/maps/slack.test.ts)
-- [Integration test for expected output for given input](https://github.com/superfaceai/station/blob/main/capabilities/address/clean-address/maps/smartystreets.test.ts)
+- [Integration test for expected result data format](https://github.com/superfaceai/station/blob/51b021ddcdccc772c9a2cd1591c9936b9ba64a5d/grid/communication/send-message/maps/send-message.ts)
+- [Integration test for expected output for given input](https://github.com/superfaceai/station/blob/51b021ddcdccc772c9a2cd1591c9936b9ba64a5d/grid/address/clean-address/maps/clean-address.ts)
 
 > If you wish to use your new capability in another Node.js application, please refer to [the following guide](./run-capability.md).


### PR DESCRIPTION
- Comlink map examples were pointing to the `/capabilities/` directory; replaced with commit permalink
- I noticed a few links pointing to Comlink spec as "reference"

Thanks to @tmladek for heads up!