### PR TITLE
Fix highlighted code block background color

### DIFF
--- a/.github/workflows/ci-cd-pipeline.yml
+++ b/.github/workflows/ci-cd-pipeline.yml
@@ -15,7 +15,6 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: '16.x'
-
       - name: Install dependencies
         run: yarn install --frozen-lockfile
 
@@ -39,7 +38,10 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           env: ${{ env.GITHUB_HEAD_REF_SLUG_URL }}
           ref: ${{ github.head_ref }}
-
+      - uses: actions/setup-node@v3
+        name: Setup Node.js
+        with:
+          node-version: lts/*
       - uses: amondnet/vercel-action@v20
         name: Deploy to Vercel
         id: vercel_preview
@@ -76,7 +78,10 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           auto_inactive: true
           env: Production
-
+      - uses: actions/setup-node@v3
+        name: Setup Node.js
+        with:
+          node-version: lts/*
       - uses: amondnet/vercel-action@v20
         name: Deploy to Vercel
         id: vercel_production

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -22,6 +22,8 @@
   --tailwind-gray-900: #111827;
 
   --ifm-navbar-height: 4rem;
+
+  --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.1);
 }
 
 html[data-theme='dark'] {
@@ -42,14 +44,13 @@ button[class*='backToTopButton'] {
 }
 
 .docusaurus-highlight-code-line {
-  background-color: rgba(0, 0, 0, 0.1);
   display: block;
   margin: 0 calc(-1 * var(--ifm-pre-padding));
   padding: 0 var(--ifm-pre-padding);
 }
 
-html[data-theme='dark'] .docusaurus-highlight-code-line {
-  background-color: rgba(0, 0, 0, 0.3);
+html[data-theme='dark'] {
+  --docusaurus-highlighted-code-line-bg: rgba(0, 0, 0, 0.3);
 }
 
 /* Navbar */


### PR DESCRIPTION
This PR fixes styling of highlighted code block in light and dark mode by changing custom.css according to Docusaurus documentation: https://docusaurus.io/docs/markdown-features/code-blocks#line-highlighting.

Light mode before fix:
<img width="842" alt="image" src="https://user-images.githubusercontent.com/5206165/178996541-2edbac53-0ba7-4a3c-ab84-b57560d9dcc9.png">

Light mode after fix:
<img width="842" alt="image" src="https://user-images.githubusercontent.com/5206165/178996317-f2f4f284-a97c-4718-bb18-74c241616701.png">

Dark mode before fix:
<img width="842" alt="image" src="https://user-images.githubusercontent.com/5206165/178996705-6282414a-d5fa-4969-9379-3a6a224a35a1.png">

Dark mode after fix:
<img width="842" alt="image" src="https://user-images.githubusercontent.com/5206165/178996835-022f0063-5fad-4279-8e4e-347268f25277.png">

