### PR TITLE
Fix navigation on home page

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -12,68 +12,68 @@ Superface is the AI for APIs. It makes creating API integrations faster, and mor
 <div className="row padding-bottom--lg">
   <div className="col col--6">
     <div className="card shadow">
-      <a href="./introduction/getting-started" class="menu__link">
-      <div className="card__body">
-        <h3>🏃 Quick Starts</h3>
-        <p>Examples of how to get up and running creating Comlinks with the Superface CLI and OneSDK.
-        </p>
-      </div>
+      <a href="./introduction/getting-started" className="menu__link">
+        <div className="card__body">
+          <h3>🏃 Quick Starts</h3>
+          <p>Examples of how to get up and running creating Comlinks with the Superface CLI and OneSDK.
+          </p>
+        </div>
       </a>
     </div>
   </div>
 
-<div className="col col--6">
+  <div className="col col--6">
     <div className="card shadow">
-      <a href="./guides/how-to-create" class="menu__link">
-      <div className="card__body">
-        <h3>🔎 Guides</h3>
-        <p>Looking for more in depth knowledge? Check out our list of guides that get into greater detail.
-        </p>
-      </div>
-      </a>
-    </div>
-  </div>
-<div className="col col--6">
-    <div className="card shadow">
-      <a href="./api-examples/hubspot" class="menu__link">
-      <div className="card__body">
-        <h3>💼 Use Case Examples</h3>
-        <p>From HubSpot to Pipedrive. Use case examples demonstrate different uses of Superface with real-world APIs.
-        </p>
-      </div>
-      </a>
-    </div>
-  </div>
-<div className="col col--6">
-    <div className="card shadow">
-      <a href="./examples/nodejs" class="menu__link">
-      <div className="card__body">
-        <h3>💻 SDK Examples</h3>
-        <p>Implementation examples for OneSDK using Node.js, Python and Cloudflare Workers.
-        </p>
-      </div>
+      <a href="./guides/how-to-create" className="menu__link">
+        <div className="card__body">
+          <h3>🔎 Guides</h3>
+          <p>Looking for more in depth knowledge? Check out our list of guides that get into greater detail.
+          </p>
+        </div>
       </a>
     </div>
   </div>
   <div className="col col--6">
     <div className="card shadow">
-      <a href="./support" class="menu__link">
-      <div className="card__body">
-        <h3>ℹ️ Help & Support</h3>
-        <p>If you're looking for help, support or want to talk business. We're here for you!
-        </p>
-      </div>
+      <a href="./api-examples/hubspot" className="menu__link">
+        <div className="card__body">
+          <h3>💼 Use Case Examples</h3>
+          <p>From HubSpot to Pipedrive. Use case examples demonstrate different uses of Superface with real-world APIs.
+          </p>
+        </div>
       </a>
     </div>
   </div>
-<div className="col col--6">
+  <div className="col col--6">
     <div className="card shadow">
-      <a href="./faq" class="menu__link">
-      <div className="card__body">
-        <h3>❓ FAQs</h3>
-        <p>View some of the frequently asked questions regarding Superface, CLI and OneSDK.
-        </p>
-      </div>
+      <a href="./examples/nodejs" className="menu__link">
+        <div className="card__body">
+          <h3>💻 SDK Examples</h3>
+          <p>Implementation examples for OneSDK using Node.js, Python and Cloudflare Workers.
+          </p>
+        </div>
+      </a>
+    </div>
+  </div>
+  <div className="col col--6">
+    <div className="card shadow">
+      <a href="./support" className="menu__link">
+        <div className="card__body">
+          <h3>ℹ️ Help & Support</h3>
+          <p>If you're looking for help, support or want to talk business. We're here for you!
+          </p>
+        </div>
+      </a>
+    </div>
+  </div>
+  <div className="col col--6">
+    <div className="card shadow">
+      <a href="./faq" className="menu__link">
+        <div className="card__body">
+          <h3>❓ FAQs</h3>
+          <p>View some of the frequently asked questions regarding Superface, CLI and OneSDK.
+          </p>
+        </div>
       </a>
     </div>
   </div>

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -12,7 +12,7 @@ Superface is the AI for APIs. It makes creating API integrations faster, and mor
 <div className="row padding-bottom--lg">
   <div className="col col--6">
     <div className="card shadow">
-      <a href="./introduction/getting-started" className="menu__link">
+      <a href="/docs/introduction/getting-started" className="menu__link">
         <div className="card__body">
           <h3>🏃 Quick Starts</h3>
           <p>Examples of how to get up and running creating Comlinks with the Superface CLI and OneSDK.
@@ -21,10 +21,9 @@ Superface is the AI for APIs. It makes creating API integrations faster, and mor
       </a>
     </div>
   </div>
-
   <div className="col col--6">
     <div className="card shadow">
-      <a href="./guides/how-to-create" className="menu__link">
+      <a href="/docs/guides/how-to-create" className="menu__link">
         <div className="card__body">
           <h3>🔎 Guides</h3>
           <p>Looking for more in depth knowledge? Check out our list of guides that get into greater detail.
@@ -35,7 +34,7 @@ Superface is the AI for APIs. It makes creating API integrations faster, and mor
   </div>
   <div className="col col--6">
     <div className="card shadow">
-      <a href="./api-examples/hubspot" className="menu__link">
+      <a href="/docs/api-examples/hubspot" className="menu__link">
         <div className="card__body">
           <h3>💼 Use Case Examples</h3>
           <p>From HubSpot to Pipedrive. Use case examples demonstrate different uses of Superface with real-world APIs.
@@ -46,7 +45,7 @@ Superface is the AI for APIs. It makes creating API integrations faster, and mor
   </div>
   <div className="col col--6">
     <div className="card shadow">
-      <a href="./examples/nodejs" className="menu__link">
+      <a href="/docs/examples/nodejs" className="menu__link">
         <div className="card__body">
           <h3>💻 SDK Examples</h3>
           <p>Implementation examples for OneSDK using Node.js, Python and Cloudflare Workers.
@@ -57,7 +56,7 @@ Superface is the AI for APIs. It makes creating API integrations faster, and mor
   </div>
   <div className="col col--6">
     <div className="card shadow">
-      <a href="./support" className="menu__link">
+      <a href="/docs/support" className="menu__link">
         <div className="card__body">
           <h3>ℹ️ Help & Support</h3>
           <p>If you're looking for help, support or want to talk business. We're here for you!
@@ -68,7 +67,7 @@ Superface is the AI for APIs. It makes creating API integrations faster, and mor
   </div>
   <div className="col col--6">
     <div className="card shadow">
-      <a href="./faq" className="menu__link">
+      <a href="/docs/faq" className="menu__link">
         <div className="card__body">
           <h3>❓ FAQs</h3>
           <p>View some of the frequently asked questions regarding Superface, CLI and OneSDK.
@@ -80,7 +79,7 @@ Superface is the AI for APIs. It makes creating API integrations faster, and mor
 </div>
 
 :::caution Deprecation Notice
-We recently started deprecating the previous version of Superface CLI (before 4.0.0), OneSDK (before 3.0.0, for Node.js only) and our provider use case catalog. If you are looking for the documentation for these, check out our [Classic Docs](./classic) section.
+We recently started deprecating the previous version of Superface CLI (before 4.0.0), OneSDK (before 3.0.0, for Node.js only) and our provider use case catalog. If you are looking for the documentation for these, check out our [Classic Docs](./classic/index.mdx) section.
 :::
 
 ## Why Superface?

--- a/docs/reference/superjson.mdx
+++ b/docs/reference/superjson.mdx
@@ -1,5 +1,5 @@
 ---
-slug: /classic/reference/superjson
+slug: /reference/superjson
 displayed_sidebar: referenceSidebar
 ---
 

--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -41,7 +41,8 @@ module.exports = {
           label: 'Documentation',
         },
         {
-          href: '/classic',
+          type: 'doc',
+          docId: 'classic/index',
           label: 'Classic Docs',
           position: 'right',
         },

--- a/sidebars.js
+++ b/sidebars.js
@@ -16,15 +16,15 @@ const guides = {
   label: 'Guides',
   collapsed: true,
   items: [
-        'guides/how-to-create',
-        'guides/setup-the-environment',
-        'guides/editing-provider-files',
-        'guides/setting-security-schemes',
-        'guides/using-multiple-providers',
-        'guides/debugging-onesdk',
-        'guides/test-use-case',
-        'guides/api-keys'
-      ]
+    'guides/how-to-create',
+    'guides/setup-the-environment',
+    'guides/editing-provider-files',
+    'guides/setting-security-schemes',
+    'guides/using-multiple-providers',
+    'guides/debugging-onesdk',
+    'guides/test-use-case',
+    'guides/api-keys'
+  ]
 };
 
 const classicGuides = {
@@ -75,8 +75,7 @@ module.exports = {
           type: 'doc',
           id: 'introduction/getting-started',
           label: 'Superface in 5 minutes'
-        }
-        ,
+        },
         'introduction/quick-start',
         'introduction/quick-start-sdk'
       ]


### PR DESCRIPTION
- corrects slug of new superjson reference
- renames index.md to index.mds and uses className over class
- uses absolute urls for cards on home
- fixes header link to classic docs