### PR TITLE
chore: add index for api examples

### DIFF
--- a/docs/api-examples/index.mdx
+++ b/docs/api-examples/index.mdx
@@ -1,0 +1,110 @@
+---
+slug: /api-examples
+id: index
+---
+
+# API Examples
+
+Superface is the AI for APIs. It makes creating API integrations faster, and more manageable so you can focus on developing your application.
+
+<div className="row padding-bottom--lg">
+  <div className="col col--6">
+    <div className="card shadow">
+      <a href="/docs/api-examples/hubspot" className="menu__link">
+        <div className="card__body">
+          <h3>HubSpot</h3>
+          <p>
+            Use the HubSpot V3 API to retrive a list of companies in the CRM.
+          </p>
+        </div>
+      </a>
+    </div>
+  </div>
+  <div className="col col--6">
+    <div className="card shadow">
+      <a href="/docs/api-examples/infobip" className="menu__link">
+        <div className="card__body">
+          <h3>InfoBip</h3>
+          <p>Send an SMS message from your virtual number to another number.</p>
+        </div>
+      </a>
+    </div>
+  </div>
+  <div className="col col--6">
+    <div className="card shadow">
+      <a href="/docs/api-examples/lob" className="menu__link">
+        <div className="card__body">
+          <h3>Lob</h3>
+          <p>
+            Add a new address that can be used to send postcards, letters, and
+            even checks.
+          </p>
+        </div>
+      </a>
+    </div>
+  </div>
+  <div className="col col--6">
+    <div className="card shadow">
+      <a href="/docs/api-examples/notion" className="menu__link">
+        <div className="card__body">
+          <h3>Notion</h3>
+          <p>
+            This use case allows you to list all of the users in your Notion
+            workspace.
+          </p>
+        </div>
+      </a>
+    </div>
+  </div>
+  <div className="col col--6">
+    <div className="card shadow">
+      <a href="/docs/api-examples/pagerduty" className="menu__link">
+        <div className="card__body">
+          <h3>PagerDuty</h3>
+          <p>
+            List the most recent reported incidents from your PagerDuty account.
+          </p>
+        </div>
+      </a>
+    </div>
+  </div>
+  <div className="col col--6">
+    <div className="card shadow">
+      <a href="/docs/api-examples/pipedrive" className="menu__link">
+        <div className="card__body">
+          <h3>Pipedrive</h3>
+          <p>
+            This use case allows you to list all of the Organizations in your
+            Pipedrive CRM.
+          </p>
+        </div>
+      </a>
+    </div>
+  </div>
+  <div className="col col--6">
+    <div className="card shadow">
+      <a href="/docs/api-examples/resend" className="menu__link">
+        <div className="card__body">
+          <h3>Resend</h3>
+          <p>
+            Uses Resend's email API to send an email message from an application
+            to a specific email address.
+          </p>
+        </div>
+      </a>
+    </div>
+  </div>
+  <div className="col col--6">
+    <div className="card shadow">
+      <a href="/docs/api-examples/slack" className="menu__link">
+        <div className="card__body">
+          <h3>Slack</h3>
+          <p>
+            Uses Slack's Web API to list 5 public channels in your Slack
+            workspace.
+          </p>
+        </div>
+      </a>
+    </div>
+  </div>
+</div>

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -15,7 +15,9 @@ Superface is the AI for APIs. It makes creating API integrations faster, and mor
       <a href="/docs/introduction/getting-started" className="menu__link">
         <div className="card__body">
           <h3>🏃 Quick Starts</h3>
-          <p>Examples of how to get up and running creating Comlinks with the Superface CLI and OneSDK.
+          <p>
+            Examples of how to get up and running creating Comlinks with the
+            Superface CLI and OneSDK.
           </p>
         </div>
       </a>
@@ -26,7 +28,9 @@ Superface is the AI for APIs. It makes creating API integrations faster, and mor
       <a href="/docs/guides/how-to-create" className="menu__link">
         <div className="card__body">
           <h3>🔎 Guides</h3>
-          <p>Looking for more in depth knowledge? Check out our list of guides that get into greater detail.
+          <p>
+            Looking for more in depth knowledge? Check out our list of guides
+            that get into greater detail.
           </p>
         </div>
       </a>
@@ -34,10 +38,12 @@ Superface is the AI for APIs. It makes creating API integrations faster, and mor
   </div>
   <div className="col col--6">
     <div className="card shadow">
-      <a href="/docs/api-examples/hubspot" className="menu__link">
+      <a href="/docs/api-examples" className="menu__link">
         <div className="card__body">
           <h3>💼 Use Case Examples</h3>
-          <p>From HubSpot to Pipedrive. Use case examples demonstrate different uses of Superface with real-world APIs.
+          <p>
+            From HubSpot to Pipedrive. Use case examples demonstrate different
+            uses of Superface with real-world APIs.
           </p>
         </div>
       </a>
@@ -48,7 +54,9 @@ Superface is the AI for APIs. It makes creating API integrations faster, and mor
       <a href="/docs/examples/nodejs" className="menu__link">
         <div className="card__body">
           <h3>💻 SDK Examples</h3>
-          <p>Implementation examples for OneSDK using Node.js, Python and Cloudflare Workers.
+          <p>
+            Implementation examples for OneSDK using Node.js, Python and
+            Cloudflare Workers.
           </p>
         </div>
       </a>
@@ -59,7 +67,9 @@ Superface is the AI for APIs. It makes creating API integrations faster, and mor
       <a href="/docs/support" className="menu__link">
         <div className="card__body">
           <h3>ℹ️ Help & Support</h3>
-          <p>If you're looking for help, support or want to talk business. We're here for you!
+          <p>
+            If you're looking for help, support or want to talk business. We're
+            here for you!
           </p>
         </div>
       </a>
@@ -70,7 +80,9 @@ Superface is the AI for APIs. It makes creating API integrations faster, and mor
       <a href="/docs/faq" className="menu__link">
         <div className="card__body">
           <h3>❓ FAQs</h3>
-          <p>View some of the frequently asked questions regarding Superface, CLI and OneSDK.
+          <p>
+            View some of the frequently asked questions regarding Superface, CLI
+            and OneSDK.
           </p>
         </div>
       </a>

--- a/sidebars.js
+++ b/sidebars.js
@@ -83,7 +83,8 @@ module.exports = {
     guides,
     {
       type: 'category',
-      label: 'Use Case Examples',
+      label: 'API Examples',
+      link: { type: 'doc', id: 'api-examples/index' },
       collapsed: true,
       items: [
         'api-examples/hubspot',

--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -205,3 +205,7 @@ aside.docSidebarContainer_node_modules-\@docusaurus-theme-classic-lib-next-theme
   /* needed because of invisible .anchor with display: block */
   float: left;
 }
+
+.card {
+  margin-bottom: 1rem;
+}


### PR DESCRIPTION
Adds an index page for the API examples so that they can all be shown in one place rather than linking directly to HubSpot.