### PR TITLE
Update: Add guide for profiles with multiple providers

### DIFF
--- a/docs/guides/comlink-profile-multiple-providers.md
+++ b/docs/guides/comlink-profile-multiple-providers.md
@@ -1,0 +1,54 @@
+# Reuse Comlink profiles with multiple providers
+
+When using the Superface CLI, it is possible to generate Comlink profiles for use cases and map them to different providers.
+
+## Example
+
+We will use a familiar use case, sending an email to demonstrate this.
+
+We want to do this using two different services, [Resend](https://resend.com) and [SendGrid](https://sendgrid.com).
+
+### Set up providers
+
+Start by creating providers definitions for both of those services from their respective Open API Specifications:
+
+```shell title="Resend"
+superface prepare https://raw.githubusercontent.com/resendlabs/resend-openapi/main/resend.yaml resend
+```
+
+```shell title="SendGrid"
+superface prepare https://raw.githubusercontent.com/sendgrid/sendgrid-oai/main/oai.yaml sendgrid
+```
+
+### Create a use case profile
+
+Next, create a Comlink profile for the _send an email_ use case. We'll use Resend as the default provider and explicitly set our profile ID to `emails/send-an-email`.
+
+```shell
+superface new resend "send an email" email/send-an-email
+```
+
+At this point, Superface will create a new Comlink profile in the `superface` directory named `email.send-an-email.profile`.
+
+### Map the profile to providers
+
+To create the maps that Superface's OneSDK can use to execute this use case with any provider, run the `superface map` command for each provider we want to use.
+
+```shell title="Create a map for Resend"
+superface map resend email/send-an-email
+```
+
+```shell title="Create a map for SendGrid"
+superface map sendgrid email/send-an-email
+```
+
+As you can see, the profile referenced in the above commands is the same; only the provider name has changed.
+
+At this point map files and executable examples will be created for each provider.
+
+### Add additional providers
+
+If in future you want to add some additional providers, such as Mailgun, you would:
+
+1. Run `superface prepare <url-for-mailgun-api-spec> mailgun`
+2. Map to the same profile using `superface map mailgun email/send-an-email`

--- a/docs/guides/using-multiple-providers.mdx
+++ b/docs/guides/using-multiple-providers.mdx
@@ -1,7 +1,7 @@
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-# Using multiple providers
+# Using multiple providers in OneSDK
 
 Consuming a single use case from multiple providers is at heart of Superface.
 **You can add as many providers as you need for every profile.**

--- a/sidebars.js
+++ b/sidebars.js
@@ -20,6 +20,7 @@ const guides = {
     'guides/setup-the-environment',
     'guides/editing-provider-files',
     'guides/setting-security-schemes',
+    'guides/comlink-profile-multiple-providers',
     'guides/using-multiple-providers',
     'guides/debugging-onesdk',
     'guides/test-use-case',


### PR DESCRIPTION
Adds:
- New guide describing the process of using multiple providers with the same Comlink profile
- Adds new guide to the Guides menu

Modifies:
- Changed the name of the existing multiple provider guide to make it more explicit that it's a OneSDK thing.