### PR TITLE
update: clearer OS install instructions

### DIFF
--- a/docs/introduction/install-superface.mdx
+++ b/docs/introduction/install-superface.mdx
@@ -1,6 +1,6 @@
 # Install Superface
 
-Our CLI is a command-line utility that acts as your starting point for working with Superface, from creating your account through all the steps to get your first API use case up and running.
+Superface CLI is your starting point for working with Superface, from creating your account through all the steps to get your first API use case up and running.
 
 ## macOS/Linux
 
@@ -30,12 +30,4 @@ Alternatively, if using Windows Subsystem for Linux (WSL), you can also install 
 
 Once installed, you will be able to use the CLI directly from your command-line by running either the `superface` or `sf` commands.
 
-To get started, you can run either of the following commands:
-
-```bash
-superface --help
-```
-
-```bash
-superface login
-```
+To get started using the CLI you need a Superface account, you can [create an account](https://superface.ai/create-account) by signing up or running `sf login`.

--- a/docs/introduction/install-superface.mdx
+++ b/docs/introduction/install-superface.mdx
@@ -1,0 +1,41 @@
+# Install Superface
+
+Our CLI is a command-line utility that acts as your starting point for working with Superface, from creating your account through all the steps to get your first API use case up and running.
+
+## macOS/Linux
+
+If you have the [Homebrew](https://brew.sh) package manager install, Superface CLI can be install by running:
+
+```bash
+brew install superfaceai/cli/superface
+```
+
+If not, you can install it using [NPM](https://npmjs.org) by running:
+
+```bash
+npm install -g @superfaceai/cli@latest
+```
+
+## Windows
+
+On Windows, you can install it using [NPM](https://npmjs.org) by running:
+
+```bash
+npm install -g @superfaceai/cli@latest
+```
+
+Alternatively, if using Windows Subsystem for Linux (WSL), you can also install [Homebrew](https://brew.sh/) and install the CLI using that.
+
+## After installing
+
+Once installed, you will be able to use the CLI directly from your command-line by running either the `superface` or `sf` commands.
+
+To get started, you can run either of the following commands:
+
+```bash
+superface --help
+```
+
+```bash
+superface login
+```

--- a/sidebars.js
+++ b/sidebars.js
@@ -72,13 +72,14 @@ module.exports = {
       label: 'Getting started',
       collapsed: false,
       items: [
+        'introduction/install-superface',
+        'introduction/quick-start',
+        'introduction/quick-start-sdk',
         {
           type: 'doc',
           id: 'introduction/getting-started',
           label: 'Superface in 5 minutes'
-        },
-        'introduction/quick-start',
-        'introduction/quick-start-sdk'
+        }
       ]
     },
     guides,


### PR DESCRIPTION
Creates a specific page for install instructions, to specifically call out the different options for macOS and Windows.