### PR TITLE
Simplified switch for logs relevant for OneSDK consumer

### DIFF
--- a/docs/guides/debugging-onesdk.mdx
+++ b/docs/guides/debugging-onesdk.mdx
@@ -11,21 +11,21 @@ You can set the debug level for OneSDK via your environment. There are two optio
 ### ONESDK_LOG
 
 ```shell
-ONESDK_LOG=warn #trace, error, info, warn
+ONESDK_LOG=on # on, yes, true, 1
 ```
 
-`ONESDK_LOG` sets the general logging level for OneSDK.
+`ONESDK_LOG` turns basic logging for OneSDK lifecycle and HTTP transactions logging.
 
 ## Setting debug options at runtime
 
 You can also pass these variables to your application at runtime. For example:
 
 ```shell
-ONESDK_LOG=trace node index.mjs
+ONESDK_LOG=on node index.mjs
 ```
 
 You can also provide this option when using the CLI during the `execute` command:
 
 ```shell
-ONESDK_LOG=trace superface execute <provider-name> <scope/use-case>
+ONESDK_LOG=on superface execute <provider-name> <scope/use-case>
 ```

--- a/docs/guides/debugging-onesdk.mdx
+++ b/docs/guides/debugging-onesdk.mdx
@@ -14,7 +14,7 @@ You can set the debug level for OneSDK via your environment. There are two optio
 ONESDK_LOG=on # on, yes, true, 1
 ```
 
-`ONESDK_LOG` turns basic logging for OneSDK lifecycle and HTTP transactions logging.
+`ONESDK_LOG` controls basic logging for OneSDK lifecycle and HTTP transactions logging.
 
 ## Setting debug options at runtime
 

--- a/docs/introduction/getting-started.mdx
+++ b/docs/introduction/getting-started.mdx
@@ -156,7 +156,7 @@ node --experimental-wasi-unstable-preview1 index.mjs
 
 ### Debugging
 
-If you run into errors and need more information about what's happening under the hood, you can set the environment variable `ONESDK_LOG` to `debug` to see API calls from OneSDK to the API of your chosen provider:
+If you run into errors and need more information about what's happening under the hood, you can set the environment variable `ONESDK_LOG` to `on` to see API calls from OneSDK to the API of your chosen provider:
 
 :::caution
 
@@ -165,7 +165,7 @@ This can print out potentially sensitive information, like API keys and access t
 :::
 
 ```shell
-ONESDK_LOG="debug" node --experimental-wasi-unstable-preview1 index.mjs
+ONESDK_LOG="on" node --experimental-wasi-unstable-preview1 index.mjs
 ```
 
 </div>

--- a/docs/introduction/quick-start-sdk.mdx
+++ b/docs/introduction/quick-start-sdk.mdx
@@ -84,10 +84,10 @@ node --experimental-wasi-unstable-preview1 index.mjs
 
 ### Debugging
 
-Set the environment variable `ONESDK_LOG` to `trace` to see API calls from OneSDK to the API you are connecting to:
+Set the environment variable `ONESDK_LOG` to `on` to see API calls from OneSDK to the API you are connecting to:
 
 ```shell
-ONESDK_LOG="trace" node --experimental-wasi-unstable-preview1 index.mjs
+ONESDK_LOG="on" node --experimental-wasi-unstable-preview1 index.mjs
 ```
 
 :::caution


### PR DESCRIPTION
With new beta (will be released today Aug 14th) of OneSDK switch to see user relevant logs changed. Now there is just on/off, no actual levels.