### PR TITLE
update: highlight WASI flag not needed depending on Node version

### DIFF
--- a/docs/examples/nodejs.mdx
+++ b/docs/examples/nodejs.mdx
@@ -84,10 +84,16 @@ main();
 
 ### Run the code
 
-Because OneSDK is built with Wasm, and WASI support for Node.js is still experimental, to run your file you will need to pass an additional flag.
+If using a version of Node.js before `18.17.0` you will need to enable WASI by providing an extra flag:
 
 ```shell
 node --experimental-wasi-unstable-preview1 index.mjs
+```
+
+For later versions of Node.js you can run the script as normal:
+
+```shell
+node index.mjs
 ```
 
 </div>

--- a/docs/introduction/getting-started.mdx
+++ b/docs/introduction/getting-started.mdx
@@ -175,10 +175,16 @@ main();
 
 ### Test and confirm
 
-It's time to run your app! Because the Superface OneSDK is built with Wasm, it requires that you pass the `--experimental-wasi-unstable-preview1` flag when running Node.js (>18.0.0).
+It's time to run your app! Because the Superface OneSDK is built with Wasm, it requires that you pass the `--experimental-wasi-unstable-preview1` flag when running Node.js version <18.17.0.
 
 ```shell
 node --experimental-wasi-unstable-preview1 index.mjs
+```
+
+For later versions of Node.js, you can run the command as usual with no flag:
+
+```shell
+node index.mjs
 ```
 
 ### Debugging
@@ -192,7 +198,7 @@ This can print out potentially sensitive information, like API keys and access t
 :::
 
 ```shell
-ONESDK_LOG="on" node --experimental-wasi-unstable-preview1 index.mjs
+ONESDK_LOG="on" node index.mjs
 ```
 
 </div>

--- a/docs/introduction/getting-started.mdx
+++ b/docs/introduction/getting-started.mdx
@@ -175,7 +175,7 @@ main();
 
 ### Test and confirm
 
-It's time to run your app! Because the Superface OneSDK is built with Wasm, it requires that you pass the `--experimental-wasi-unstable-preview1` flag when running Node.js version < `18.17.0`.
+It's time to run your app! Because the Superface OneSDK is built with WebAssembly and uses WASI, it requires that you pass the `--experimental-wasi-unstable-preview1` flag when running Node.js version < `18.17.0`.
 
 ```shell
 node --experimental-wasi-unstable-preview1 index.mjs

--- a/docs/introduction/getting-started.mdx
+++ b/docs/introduction/getting-started.mdx
@@ -175,7 +175,7 @@ main();
 
 ### Test and confirm
 
-It's time to run your app! Because the Superface OneSDK is built with Wasm, it requires that you pass the `--experimental-wasi-unstable-preview1` flag when running Node.js version <18.17.0.
+It's time to run your app! Because the Superface OneSDK is built with Wasm, it requires that you pass the `--experimental-wasi-unstable-preview1` flag when running Node.js version < `18.17.0`.
 
 ```shell
 node --experimental-wasi-unstable-preview1 index.mjs

--- a/docs/introduction/quick-start-sdk.mdx
+++ b/docs/introduction/quick-start-sdk.mdx
@@ -176,10 +176,16 @@ It's time to run your app!
 
 <TabItem value="nodejs">
 
-Because the Superface OneSDK is built with WASM, it requires that you pass the `--experimental-wasi-unstable-preview1` flag.
+Because the Superface OneSDK is built with WASM, it requires that you pass the `--experimental-wasi-unstable-preview1` flag if using Node.js version `18.17.0` or earlier.
 
 ```shell
 node --experimental-wasi-unstable-preview1 index.mjs
+```
+
+For later versions of Node.js, you can run the script as normal:
+
+```shell
+node index.mjs
 ```
 
 </TabItem>


### PR DESCRIPTION
Updates Node.js run examples to include that you don't need to use the WASI flag with later versions of Node.js