### PR TITLE
chore: update Algolia config

### DIFF
--- a/.github/algolia/config.json
+++ b/.github/algolia/config.json
@@ -1,6 +1,7 @@
 {
   "index_name": "production",
   "start_urls": ["https://superface.ai/docs/"],
+  "stop_urls": ["https://superface.ai/docs/classic/"],
   "selectors": {
     "lvl0": {
       "selector": "article h1",


### PR DESCRIPTION
Updates the Algolia config to add stop URLs that include `/classic` so we don't index the old documentation anymore.